### PR TITLE
Add Gemini example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # AI-Powered Interview
 
 This project provides a simple interface for running a mock interview. The user will speak and the interviewer will also respond. The entire conversation is transcribed so the system can analyze it and generate feedback.
+
+## Using Gemini for Responses
+
+To experiment with Gemini's free AI credits, a small example script is provided in `src/gemini_example.py`.
+
+### Setup
+
+1. Create a Python virtual environment and install the required library:
+
+```bash
+pip install google-generativeai
+```
+
+2. Obtain an API key for the Gemini API and export it as an environment variable:
+
+```bash
+export GEMINI_API_KEY=<YOUR_API_KEY>
+```
+
+### Run the Example
+
+Execute the script with:
+
+```bash
+python src/gemini_example.py
+```
+
+Then enter a prompt when asked. The script sends the prompt to the Gemini API and prints the AI's response.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-generativeai

--- a/src/gemini_example.py
+++ b/src/gemini_example.py
@@ -1,0 +1,23 @@
+import os
+from google.generativeai import configure, GenerativeModel
+
+def generate_text(prompt: str) -> str:
+    """Generate a completion using Gemini API."""
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Please set the GEMINI_API_KEY environment variable.")
+
+    configure(api_key=api_key)
+    model = GenerativeModel("gemini-pro")
+    response = model.generate_content(prompt)
+    return response.text
+
+
+def main() -> None:
+    prompt = input("Enter a prompt: ")
+    result = generate_text(prompt)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python example that calls the Gemini API
- document how to run the Gemini example
- add requirements file

## Testing
- `python -m py_compile src/gemini_example.py`

------
https://chatgpt.com/codex/tasks/task_e_684c7cf5e7a8832991a2743b2a36868b